### PR TITLE
fix: docker image go-sqlite3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src
 COPY go.sum go.mod ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /bin/app ./cmd/snapshotter
+RUN go build -o /bin/app ./cmd/snapshotter
 
 FROM debian:stable-slim
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Due to error `time="2025-01-29T14:56:17Z" level=fatal msg="failed to start" error="failed to initialize database: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub"`