### PR TITLE
fix: only build amd64 docker img

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -27,3 +27,4 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           image_name: ${{ github.repository }}
           push: true
+          platforms: linux/amd64


### PR DESCRIPTION
to avoid current buildx problem with `#25 152.1 gcc: internal compiler error: Segmentation fault signal terminated program cc1`