### PR TITLE
fix: detect failed snapshots instead of publishing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,55 @@ If you're happy with the version and the timestamp of the most recent snapshot, 
 curl -O https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.tar.zst
 
 # Or... download and untar at the same time. Safes you disk space, so you don't have to store the full compressed file.
-curl -s -L https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.tar.zst | tar -I zstd -xvf - -C $PATH_TO_YOUR_GETH_DATA_DIR
+# Note the trailing /geth: the geth archive is the datadir's inner geth/ directory, not its root.
+curl -s -L https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.tar.zst | tar -I zstd -xvf - -C $PATH_TO_YOUR_GETH_DATA_DIR/geth
 
 # Or.. use a docker container with all the tools you need (curl, zstd, tar) and untar it on the fly
-docker run --rm -it -v $PATH_TO_YOUR_GETH_DATA_DIR:/data --entrypoint "/bin/sh" alpine -c "apk add --no-cache curl tar zstd && curl -s -L https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.tar.zst | tar -I zstd -xvf - -C /data"
+docker run --rm -it -v $PATH_TO_YOUR_GETH_DATA_DIR/geth:/data --entrypoint "/bin/sh" alpine -c "apk add --no-cache curl tar zstd && curl -s -L https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.tar.zst | tar -I zstd -xvf - -C /data"
 ```
+
+### Match the flags the snapshot was taken with
+
+A snapshot is a datadir produced by a node running specific flags, so the node you restore
+onto needs compatible ones. Pruning flags matter most: a pruned source omits data that an
+unpruned consumer will then try to rebuild in place.
+
+The flags vary per network, so read them off the snapshot rather than assuming:
+
+```sh
+curl -s https://snapshots.ethpandaops.io/mainnet/reth/$BLOCK_NUMBER/_snapshot_metadata.json | jq -r '.static.extra_args, .docker_image'
+```
+
+Where each client records what it was built with:
+
+- **geth** — reads the state scheme from the datadir, so you can omit `--state.scheme`;
+  passing one that conflicts fails with `incompatible state scheme`. Mainnet and sepolia
+  snapshots also use `--history.chain=postmerge`, so pre-merge history is absent.
+- **nethermind** — no sync or pruning flags; the extras are RPC modules and, off mainnet,
+  `--config=<network>`.
+- **besu** — the storage format is recorded in `DATABASE_METADATA.json` inside the archive
+  and validated on startup, so a mismatched `--data-storage-format` is rejected rather than
+  silently wrong.
+- **erigon** — the prune mode is recorded in the database and checked against `--prune.mode`
+  on startup.
+- **reth** — the only client whose config file ships inside the archive, and the only one
+  where nothing validates that config against the data. Keep the `reth.toml` at the archive
+  root: it holds both the prune config and `[static_files.blocks_per_file]`, the width of
+  every static file in the archive. Lose it and reth falls back to its defaults, tries to
+  build a segment the archive intentionally omits, and fails with `trying to append data to
+  transaction-senders as block #0 but expected block #N` — which stops the sync pipeline
+  while the node keeps peers and looks healthy. Start it with the whole `extra_args` string,
+  not a subset: any prune flag makes reth rewrite `[prune]` from the command line and save
+  the result back over `reth.toml`, so `--full` on its own re-prunes mainnet receipts to the
+  last 10064 blocks even though the archive carries them from the merge.
+
+geth and nethermind archive a subdirectory of the datadir (`geth/` and `nethermind_db/`)
+rather than its root, so extract them one level deeper — the paths in the commands above
+already account for this.
+
+Node identity is never included: `nodekey` (geth, erigon), `key` (besu) and
+`discovery-secret` (reth) are excluded from every archive, so a restored node generates its
+own.
 
 ## Configuration Options
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ type RCloneConfig struct {
 // .UploadPathPrefix is the prefix of the upload path ( e.g mainnet/geth)
 // .BlockNumber is the block number of the snapshot (e.g 123456)
 const DefaultRCloneCommandTemplate = `-ac "
+set -o pipefail &&
 apk add --no-cache tar zstd jq &&
 cd {{ .DataDir }} &&
 cat {{ .DataDir }}/_snapshot_metadata.json | jq . &&

--- a/internal/snapshotter/snapshotter.go
+++ b/internal/snapshotter/snapshotter.go
@@ -365,7 +365,7 @@ func (s *SnapShotter) StartPeriodicPolling() {
 	}
 }
 
-func (s *SnapShotter) CreateSnapshot() error {
+func (s *SnapShotter) CreateSnapshot() (err error) {
 	s.status.Lock()
 	if s.status.SnapshotInProgress {
 		s.status.Unlock()
@@ -392,6 +392,28 @@ func (s *SnapShotter) CreateSnapshot() error {
 		"dry_run": run.DryRun,
 	}).Info("starting snapshot")
 
+	// PrepareForSnapshot stops the snooper and EL on every target before it can fail, and
+	// PostSnapshotStart is the only code that starts them again. Every return below has to go
+	// through it: polling needs a synced EL to trigger the next run, so a target left stopped
+	// stays stopped until someone intervenes by hand.
+	defer func() {
+		errStart := s.PostSnapshotStart()
+		if errStart == nil {
+			return
+		}
+
+		log.WithError(errStart).Error("failed to restore service after snapshot")
+
+		// Only claim the run's status if nothing else already failed, so that a restart failure
+		// does not overwrite the reason the snapshot itself was abandoned.
+		if err == nil {
+			err = errStart
+			if errDB := s.db.UpdateSnapshotRunStatus(run.ID, "failed", errStart.Error()); errDB != nil {
+				log.WithError(errDB).Error("failed to update snapshot run status")
+			}
+		}
+	}()
+
 	if err := s.PrepareForSnapshot(); err != nil {
 		if errDB := s.db.UpdateSnapshotRunStatus(run.ID, "failed", err.Error()); errDB != nil {
 			log.WithError(errDB).Error("failed to update snapshot run status")
@@ -407,14 +429,6 @@ func (s *SnapShotter) CreateSnapshot() error {
 		return err
 	}
 
-	if err := s.PostSnapshotStart(); err != nil {
-		if errDB := s.db.UpdateSnapshotRunStatus(run.ID, "failed", err.Error()); errDB != nil {
-			log.WithError(errDB).Error("failed to update snapshot run status")
-		}
-		log.WithError(err).Error("failed to restore service after snapshot")
-		return err
-	}
-
 	if s.cfg.Global.Snapshots.DryRun {
 		log.WithFields(log.Fields{
 			"run_id": run.ID,
@@ -424,7 +438,7 @@ func (s *SnapShotter) CreateSnapshot() error {
 	if err := s.db.UpdateSnapshotRunStatus(run.ID, "success", ""); err != nil {
 		log.WithError(err).Error("failed to update snapshot run status")
 	}
-	return err
+	return nil
 }
 
 func (s *SnapShotter) PrepareForSnapshot() error {


### PR DESCRIPTION
### Truncated archives are published as successful

The upload pipeline runs under `sh -a`, which does not set `pipefail`:

```
tar -I 'zstd -T64' ... -cvf - . | rclone rcat ... snapshot.tar.zst && ... rclone rcat .../latest
```

POSIX `sh` reports only the last command's status, so the chain sees rclone's. If `tar` or `zstd` dies mid-stream, `rclone rcat` gets a clean EOF, finalises the multipart upload of a partial archive and exits 0. The `&&` chain then publishes `latest` and the run is recorded successful. Nothing downstream can tell the difference — there is no checksum or size manifest.

Setting `pipefail` aborts the chain before anything is published. Verified in the pinned `rclone/rclone:1.65.2`: busybox ash supports it, and production uses this template (no inventory overrides `cmd_template`).

### That abort is only safe if the fleet comes back

`PrepareForSnapshot` stops the snooper and EL on every target before it can fail, and `PostSnapshotStart` is the only caller of `StartEL`/`StartSnooper`. Any early return skipped it and left the fleet stopped, with no way back: the next poll needs a live EL to report synced, so `CreateSnapshot` is never reached again.

The restart now runs in a `defer`. `CreateSnapshot` gets a named return so a failed restart propagates rather than reporting success, and the defer only sets the run status when nothing else already failed, so it cannot overwrite the reason the snapshot was abandoned.

`dry_run` is unaffected — `PrepareForSnapshot` and `PostSnapshotStart` both short-circuit on it, so nothing is stopped and the defer is a no-op.

### Restore docs

Records that a restored node needs flags compatible with the ones the snapshot was taken with, and where each client keeps that state. The flags vary per network and are already published per snapshot in `_snapshot_metadata.json`.

Also corrects the geth extraction path in the existing examples: that archive is the datadir's inner `geth/` directory, so extracting at the datadir root put `chaindata` one level too high.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
