### PR TITLE
feat: publish erigon state preimages alongside snapshots 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Snapshot | `https://snapshots.ethpandaops.io/{{ network_name }}/{{ client_name }
 Block info | `https://snapshots.ethpandaops.io/{{ network_name }}/{{ client_name }}/{{ block_number }}/_snapshot_eth_getBlockByNumber.json`
 Client info | `https://snapshots.ethpandaops.io/{{ network_name }}/{{ client_name }}/{{ block_number }}/_snapshot_web3_clientVersion.json`
 Metadata | `https://snapshots.ethpandaops.io/{{ network_name }}/{{ client_name }}/{{ block_number }}/_snapshot_metadata.json`
+State preimages (erigon only) | `https://snapshots.ethpandaops.io/{{ network_name }}/erigon/{{ block_number }}/preimages.tar.zst`
 
 Possible values:
 - `network_name` -> `holesky`, `hoodi`, `sepolia`, `mainnet`.
@@ -87,6 +88,43 @@ curl -s -L https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.
 # Or.. use a docker container with all the tools you need (curl, zstd, tar) and untar it on the fly
 docker run --rm -it -v $PATH_TO_YOUR_GETH_DATA_DIR:/data --entrypoint "/bin/sh" alpine -c "apk add --no-cache curl tar zstd && curl -s -L https://snapshots.ethpandaops.io/sepolia/geth/$BLOCK_NUMBER/snapshot.tar.zst | tar -I zstd -xvf - -C /data"
 ```
+
+### State preimages (erigon)
+
+For erigon targets, the snapshotter can additionally publish a **state preimages** artifact next to the snapshot. It is produced with erigon's `snapshots export-preimages` command ([erigontech/erigon#22645](https://github.com/erigontech/erigon/pull/22645)) while the node is stopped, so it corresponds to the exact same state as `snapshot.tar.zst`. This is the input consumed by state-conversion tooling.
+
+`preimages.tar.zst` contains two files:
+
+1. `preimages.meta.json` (first member, so it can be streamed without downloading the rest): `{ "block", "stateRoot", "accounts", "storage" }`
+2. `framed.bin`: the full latest state as length-prefixed frames, one per account:
+
+```
+address[20 bytes] | slotCount[4 bytes, big-endian] | slotKey[32 bytes] * slotCount
+```
+
+Records are sorted ascending by address, and each account's storage slot keys are sorted ascending. The total size of `framed.bin` is exactly `accounts*24 + storage*32` bytes.
+
+```sh
+# Peek at the metadata without downloading framed.bin
+curl -s https://snapshots.ethpandaops.io/sepolia/erigon/$BLOCK_NUMBER/preimages.tar.zst | zstd -d | tar -xO --occurrence=1 preimages.meta.json
+
+# Download and extract
+curl -s -L https://snapshots.ethpandaops.io/sepolia/erigon/$BLOCK_NUMBER/preimages.tar.zst | tar -I zstd -xvf - -C $YOUR_OUTPUT_DIR
+```
+
+To enable it, add a `preimages` block to an erigon target (see [config.example.yaml](config.example.yaml)):
+
+```yaml
+      preimages:
+        enabled: true
+```
+
+Notes for operators:
+
+- The export runs `docker run <erigon image> snapshots export-preimages` on the node during the stopped-EL window and needs roughly `accounts*24 + storage*32` bytes of free space in the datadir volume. It extends the window for **all** targets of the run, since containers are only restarted after every upload finishes.
+- The command only exists in erigon builds from `main` after 2026-07-22 (no stable release ships it yet).
+- By default failures are best-effort: the snapshot still publishes and the block directory simply has no `preimages.tar.zst` (HTTP 404). With `required: true`, a preimage failure fails the whole run and leaves the EL containers stopped until manually restarted.
+- If you override `global.snapshots.rclone.cmd_template` with a custom template, add `--exclude=./_snapshot_preimages` to its tar invocation so a leftover export can never end up inside `snapshot.tar.zst`.
 
 ## Configuration Options
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,10 @@ global:
         RCLONE_CONFIG_MYS3_TYPE: s3
         RCLONE_CONFIG_MYS3_PROVIDER: DigitalOcean
         RCLONE_CONFIG_MYS3_ACL: public-read
+    # Optional: override the erigon preimages export/upload command templates (defaults built in).
+    # preimages:
+    #   export_cmd_template: ...
+    #   upload_cmd_template: ...
 targets:
   ssh:
     - alias: "geth"
@@ -58,3 +62,21 @@ targets:
       endpoints:
         beacon: http://localhost:5052
         execution: http://localhost:8545
+    - alias: "erigon"
+      host: "1.2.3.6"
+      user: "devops"
+      port: 22
+      data_dir: /data/hoodi/erigon/erigon
+      upload_prefix: hoodi/erigon
+      docker_containers:
+        engine_snooper: snooper-engine
+        execution: execution
+        beacon: beacon
+      endpoints:
+        beacon: http://localhost:5052
+        execution: http://localhost:8545
+      # Publish {upload_prefix}/{block}/preimages.tar.zst (see README: State preimages).
+      preimages:
+        enabled: true
+        # image: ethpandaops/erigon:main  # pin; empty = auto-detect from the execution container
+        # required: false                 # true: preimage failure fails the whole run and leaves ELs stopped

--- a/internal/clients/ssh/ssh.go
+++ b/internal/clients/ssh/ssh.go
@@ -2,13 +2,16 @@ package ssh
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -20,9 +23,10 @@ import (
 )
 
 type SSHClient struct {
-	Config       *ssh.ClientConfig
-	TargetConfig *config.SSHTargetConfig
-	RCloneConfig *config.RCloneConfig
+	Config          *ssh.ClientConfig
+	TargetConfig    *config.SSHTargetConfig
+	RCloneConfig    *config.RCloneConfig
+	PreimagesConfig *config.PreimagesConfig
 }
 
 // SnapshotMetadata represents metadata about a snapshot
@@ -31,7 +35,7 @@ type SnapshotMetadata struct {
 	Static      map[string]string `json:"static,omitempty"`
 }
 
-func NewSSHClient(privateKeyPath, privateKeyPassphrasePath, knowHostsPath string, ignoreHostKeyCheck bool, useAgent bool, rclone *config.RCloneConfig, target *config.SSHTargetConfig) *SSHClient {
+func NewSSHClient(privateKeyPath, privateKeyPassphrasePath, knowHostsPath string, ignoreHostKeyCheck bool, useAgent bool, rclone *config.RCloneConfig, preimages *config.PreimagesConfig, target *config.SSHTargetConfig) *SSHClient {
 
 	var hostkeyCallback ssh.HostKeyCallback
 	hostkeyCallback, err := knownhosts.New(knowHostsPath)
@@ -91,9 +95,10 @@ func NewSSHClient(privateKeyPath, privateKeyPassphrasePath, knowHostsPath string
 	}
 
 	return &SSHClient{
-		Config:       config,
-		TargetConfig: target,
-		RCloneConfig: rclone,
+		Config:          config,
+		TargetConfig:    target,
+		RCloneConfig:    rclone,
+		PreimagesConfig: preimages,
 	}
 }
 
@@ -342,8 +347,59 @@ func (client *SSHClient) RCloneSyncLocalToRemote(srcDir, uploadPrefix string, bl
 		return err
 	}
 
+	// Get command template, using default if not specified
+	cmdTemplate := client.RCloneConfig.CommandTemplate
+	if cmdTemplate == "" {
+		// If we don't have the template directly, use the default from config package
+		// This fallback should rarely happen since we set defaults in config.ReadFromFile
+		log.Debug("RClone command template not specified, using default from config package")
+		cmdTemplate = config.GetDefaultRCloneConfig().CommandTemplate
+	}
+
+	cmd, err := client.buildRCloneDockerCmd(srcDir, cmdTemplate, rcloneCmdVars{
+		DataDir:          srcDir,
+		UploadPathPrefix: uploadPrefix,
+		BucketName:       client.resolveBucketName(),
+		BlockNumber:      blockNumber,
+	})
+	if err != nil {
+		return err
+	}
+
+	out, err := client.RunCommand(cmd)
+	if err != nil {
+		log.WithError(err).WithField("output", out).Error("failed to rclone sync")
+		return err
+	}
+
+	return nil
+}
+
+// rcloneCmdVars are the variables exposed to rclone command templates.
+// OutDir is only set for the preimages upload template.
+type rcloneCmdVars struct {
+	DataDir          string
+	OutDir           string
+	UploadPathPrefix string
+	BucketName       string
+	BlockNumber      uint64
+}
+
+func (client *SSHClient) resolveBucketName() string {
+	if client.RCloneConfig.Env != nil {
+		if val, exists := client.RCloneConfig.Env["RCLONE_CONFIG_MYS3_BUCKET_NAME"]; exists && val != "" {
+			return val
+		}
+	}
+	log.Warn("Bucket name not found in RClone config environment variables, using default")
+	return "ethpandaops-ethereum-node-snapshots"
+}
+
+// buildRCloneDockerCmd assembles the `docker run ... rclone/rclone:<version> <payload>`
+// command, rendering cmdTemplate with vars; env keys are sorted for determinism.
+func (client *SSHClient) buildRCloneDockerCmd(mountDir, cmdTemplate string, vars rcloneCmdVars) (string, error) {
 	cmd := "docker run --rm" +
-		" -v " + srcDir + ":" + srcDir
+		" -v " + mountDir + ":" + mountDir
 
 	// Use default entrypoint if not specified
 	entrypoint := client.RCloneConfig.Entrypoint
@@ -354,58 +410,26 @@ func (client *SSHClient) RCloneSyncLocalToRemote(srcDir, uploadPrefix string, bl
 
 	// Add environment variables
 	if client.RCloneConfig.Env != nil {
-		for k, v := range client.RCloneConfig.Env {
-			cmd += fmt.Sprintf(" -e %s=%s", k, v)
+		keys := make([]string, 0, len(client.RCloneConfig.Env))
+		for k := range client.RCloneConfig.Env {
+			keys = append(keys, k)
 		}
-	}
-
-	// Get command template, using default if not specified
-	cmdTemplate := client.RCloneConfig.CommandTemplate
-	if cmdTemplate == "" {
-		// If we don't have the template directly, use the default from config package
-		// This fallback should rarely happen since we set defaults in config.ReadFromFile
-		log.Debug("RClone command template not specified, using default from config package")
-		cmdTemplate = config.GetDefaultRCloneConfig().CommandTemplate
+		sort.Strings(keys)
+		for _, k := range keys {
+			cmd += fmt.Sprintf(" -e %s=%s", k, client.RCloneConfig.Env[k])
+		}
 	}
 
 	tmpl, err := template.New("cmd").Parse(cmdTemplate)
 	if err != nil {
 		log.WithError(err).Error("failed to parse rclone cmd template")
-		return err
-	}
-
-	// Get bucket name from RClone config environment variables
-	// This is set in config.ReadFromFile from the s3 configuration
-	bucketName := ""
-	if client.RCloneConfig.Env != nil {
-		if val, exists := client.RCloneConfig.Env["RCLONE_CONFIG_MYS3_BUCKET_NAME"]; exists && val != "" {
-			bucketName = val
-		}
-	}
-
-	// If not found in rclone env, use the default
-	if bucketName == "" {
-		log.Warn("Bucket name not found in RClone config environment variables, using default")
-		// Use a default if no environment variable is set
-		bucketName = "ethpandaops-ethereum-node-snapshots"
-	}
-
-	cmdVars := struct {
-		DataDir          string
-		UploadPathPrefix string
-		BucketName       string
-		BlockNumber      uint64
-	}{
-		DataDir:          srcDir,
-		UploadPathPrefix: uploadPrefix,
-		BucketName:       bucketName,
-		BlockNumber:      blockNumber,
+		return "", err
 	}
 
 	var rcloneCmd bytes.Buffer
-	if err := tmpl.Execute(&rcloneCmd, cmdVars); err != nil {
+	if err := tmpl.Execute(&rcloneCmd, vars); err != nil {
 		log.WithError(err).Error("failed to execute rclone cmd template")
-		return err
+		return "", err
 	}
 
 	// Use default version if not specified
@@ -414,12 +438,229 @@ func (client *SSHClient) RCloneSyncLocalToRemote(srcDir, uploadPrefix string, bl
 		version = config.GetDefaultRCloneConfig().Version
 	}
 
-	cmd += " rclone/rclone:" + version + " " + rcloneCmd.String()
+	return cmd + " rclone/rclone:" + version + " " + rcloneCmd.String(), nil
+}
+
+// preimagesOutDir is inside the datadir so the existing bind mounts cover it;
+// the snapshot tar template excludes it.
+func preimagesOutDir(dataDir string) string {
+	return dataDir + "/" + config.PreimagesOutDirName
+}
+
+func (client *SSHClient) preimagesExportTemplate() string {
+	if client.PreimagesConfig != nil && client.PreimagesConfig.ExportCmdTemplate != "" {
+		return client.PreimagesConfig.ExportCmdTemplate
+	}
+	return config.DefaultPreimagesExportCmdTemplate
+}
+
+func (client *SSHClient) preimagesUploadTemplate() string {
+	if client.PreimagesConfig != nil && client.PreimagesConfig.UploadCmdTemplate != "" {
+		return client.PreimagesConfig.UploadCmdTemplate
+	}
+	return config.DefaultPreimagesUploadCmdTemplate
+}
+
+func (client *SSHClient) renderPreimagesExportCmd(image, dataDir string) (string, error) {
+	tmpl, err := template.New("preimages-export").Parse(client.preimagesExportTemplate())
+	if err != nil {
+		log.WithError(err).Error("failed to parse preimages export cmd template")
+		return "", err
+	}
+
+	cmdVars := struct {
+		Image   string
+		DataDir string
+		OutDir  string
+	}{
+		Image:   image,
+		DataDir: dataDir,
+		OutDir:  preimagesOutDir(dataDir),
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, cmdVars); err != nil {
+		log.WithError(err).Error("failed to execute preimages export cmd template")
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// PullDockerImage pulls an image on the target host.
+func (client *SSHClient) PullDockerImage(image string) error {
+	out, err := client.RunCommand(fmt.Sprintf(`docker pull "%s"`, image))
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"host":   client.TargetConfig.Alias,
+			"image":  image,
+			"output": out,
+		}).Warn("failed to pull docker image")
+		return err
+	}
+	return nil
+}
+
+// ResolvePreimagesImage returns the image to run the preimage export with:
+// the pinned image from the target config when set, otherwise the image of
+// the execution container (docker inspect works on stopped containers, and
+// reusing the EL's own image guarantees binary/datadir version compatibility).
+func (client *SSHClient) ResolvePreimagesImage() (string, error) {
+	if image := client.TargetConfig.Preimages.Image; image != "" {
+		return image, nil
+	}
+	if client.TargetConfig.DockerContainers.Execution == "" {
+		return "", fmt.Errorf("preimages: no image pinned and no execution container configured for %s", client.TargetConfig.Alias)
+	}
+	return client.GetDockerContainerImage(client.TargetConfig.DockerContainers.Execution)
+}
+
+// RunPreimagesExport runs `erigon snapshots export-preimages` in a throwaway
+// container. The EL must be stopped so the exported state matches the snapshot.
+func (client *SSHClient) RunPreimagesExport(image, dataDir string) error {
+	cmd, err := client.renderPreimagesExportCmd(image, dataDir)
+	if err != nil {
+		return err
+	}
 	out, err := client.RunCommand(cmd)
 	if err != nil {
-		log.WithError(err).WithField("output", out).Error("failed to rclone sync")
+		log.WithError(err).WithFields(log.Fields{
+			"host":   client.TargetConfig.Alias,
+			"image":  image,
+			"output": out,
+		}).Error("preimages export failed")
+		return fmt.Errorf("preimages export failed: %w", err)
+	}
+	return nil
+}
+
+// isHexRoot reports whether s is a 0x-prefixed 32-byte hex string.
+func isHexRoot(s string) bool {
+	if len(s) != 66 || !strings.HasPrefix(s, "0x") {
+		return false
+	}
+	_, err := hex.DecodeString(s[2:])
+	return err == nil
+}
+
+// validateStateRootsOutput expects exactly two well-formed 32-byte hex roots
+// in the output (preimages meta first, block dump second) and requires them to
+// match. Roots are selected by shape, so sudo/PAM noise anywhere in the merged
+// stdout+stderr is ignored.
+func validateStateRootsOutput(out string) error {
+	var roots []string
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); isHexRoot(trimmed) {
+			roots = append(roots, trimmed)
+		}
+	}
+	if len(roots) != 2 {
+		return fmt.Errorf("expected exactly 2 state roots in verification output, got %d: %q", len(roots), out)
+	}
+	if !strings.EqualFold(roots[0], roots[1]) {
+		return fmt.Errorf("state root mismatch: preimages meta has %s but snapshot block dump has %s", roots[0], roots[1])
+	}
+	return nil
+}
+
+// verifyPreimagesStateRoot requires the state root in preimages.meta.json to
+// equal the one in the dumped _snapshot_eth_getBlockByNumber.json, catching
+// commitment lag and wrong-datadir exports before upload. Block numbers are
+// deliberately not compared: the S3 dir name can lag the frozen head.
+func (client *SSHClient) verifyPreimagesStateRoot(dataDir string) error {
+	metaPath := preimagesOutDir(dataDir) + "/preimages.meta.json"
+	dumpPath := dataDir + "/_snapshot_eth_getBlockByNumber.json"
+	cmd := fmt.Sprintf(`sudo cat "%s" | jq -r .stateRoot && sudo cat "%s" | jq -r .result.stateRoot`, metaPath, dumpPath)
+	out, err := client.RunCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("preimages state root verification failed: %w (output: %s)", err, out)
+	}
+	if err := validateStateRootsOutput(out); err != nil {
+		return fmt.Errorf("preimages state root verification failed: %w", err)
+	}
+	return nil
+}
+
+// UploadPreimages uploads the export output as preimages.tar.zst to the block
+// directory via the rclone container.
+func (client *SSHClient) UploadPreimages(dataDir, uploadPrefix string, blockNumber uint64) error {
+	cmd, err := client.buildRCloneDockerCmd(dataDir, client.preimagesUploadTemplate(), rcloneCmdVars{
+		DataDir:          dataDir,
+		OutDir:           preimagesOutDir(dataDir),
+		UploadPathPrefix: uploadPrefix,
+		BucketName:       client.resolveBucketName(),
+		BlockNumber:      blockNumber,
+	})
+	if err != nil {
+		return err
+	}
+	out, err := client.RunCommand(cmd)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"host":   client.TargetConfig.Alias,
+			"output": out,
+		}).Error("preimages upload failed")
+		return fmt.Errorf("preimages upload failed: %w", err)
+	}
+	return nil
+}
+
+// CleanupPreimages removes the preimages scratch directory from the datadir.
+func (client *SSHClient) CleanupPreimages(dataDir string) error {
+	if dataDir == "" || dataDir == "/" {
+		return fmt.Errorf("refusing to clean up preimages scratch dir for unsafe data dir %q", dataDir)
+	}
+	out, err := client.RunCommand(fmt.Sprintf(`sudo rm -rf "%s"`, preimagesOutDir(dataDir)))
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"host":   client.TargetConfig.Alias,
+			"output": out,
+		}).Warn("failed to clean up preimages scratch dir")
+		return err
+	}
+	return nil
+}
+
+// ExportAndUploadPreimages exports, verifies the state root, then uploads.
+// Scratch-dir cleanup always runs afterwards but never fails the flow.
+func (client *SSHClient) ExportAndUploadPreimages(dataDir, uploadPrefix string, blockNumber uint64) error {
+	if dataDir == "" || dataDir == "/" {
+		return fmt.Errorf("preimages: refusing to run against unsafe data dir %q", dataDir)
+	}
+
+	image, err := client.ResolvePreimagesImage()
+	if err != nil {
 		return err
 	}
 
+	// Warn-only: export-preimages rewrites its outputs (erigontech/erigon#22645).
+	if err := client.CleanupPreimages(dataDir); err != nil {
+		log.WithError(err).Warnf("failed to pre-clean preimages scratch dir on %s (continuing)", client.TargetConfig.Alias)
+	}
+	defer func() {
+		if err := client.CleanupPreimages(dataDir); err != nil {
+			log.WithError(err).Warnf("failed to clean up preimages scratch dir on %s (snapshot tar excludes it)", client.TargetConfig.Alias)
+		}
+	}()
+
+	t1 := time.Now()
+	log.WithFields(log.Fields{
+		"host":  client.TargetConfig.Alias,
+		"image": image,
+	}).Info("exporting state preimages")
+
+	if err := client.RunPreimagesExport(image, dataDir); err != nil {
+		return err
+	}
+	if err := client.verifyPreimagesStateRoot(dataDir); err != nil {
+		return err
+	}
+	if err := client.UploadPreimages(dataDir, uploadPrefix, blockNumber); err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{
+		"host": client.TargetConfig.Alias,
+		"took": time.Since(t1),
+	}).Info("exported and uploaded state preimages")
 	return nil
 }

--- a/internal/clients/ssh/ssh_test.go
+++ b/internal/clients/ssh/ssh_test.go
@@ -1,0 +1,207 @@
+package ssh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethpandaops/eth-snapshotter/internal/config"
+)
+
+// NewSSHClient log.Fatals on missing key/known_hosts files, so tests build the struct directly.
+func testSSHClient() *SSHClient {
+	return &SSHClient{
+		TargetConfig: &config.SSHTargetConfig{
+			Alias:   "erigon",
+			DataDir: "/data/erigon",
+		},
+		RCloneConfig: &config.RCloneConfig{
+			Env: map[string]string{
+				"RCLONE_CONFIG_MYS3_TYPE":        "s3",
+				"RCLONE_CONFIG_MYS3_BUCKET_NAME": "test-bucket",
+				"RCLONE_CONFIG_MYS3_ACL":         "public-read",
+			},
+			Version:         "1.74.2",
+			Entrypoint:      "/bin/sh",
+			CommandTemplate: config.DefaultRCloneCommandTemplate,
+		},
+	}
+}
+
+func TestBuildRCloneDockerCmdTarTemplate(t *testing.T) {
+	client := testSSHClient()
+
+	cmd, err := client.buildRCloneDockerCmd("/data/erigon", config.DefaultRCloneCommandTemplate, rcloneCmdVars{
+		DataDir:          "/data/erigon",
+		UploadPathPrefix: "hoodi/erigon",
+		BucketName:       "test-bucket",
+		BlockNumber:      123456,
+	})
+	if err != nil {
+		t.Fatalf("buildRCloneDockerCmd failed: %v", err)
+	}
+
+	wantPrefix := "docker run --rm -v /data/erigon:/data/erigon --entrypoint /bin/sh"
+	if !strings.HasPrefix(cmd, wantPrefix) {
+		t.Errorf("command should start with %q. Got: %q", wantPrefix, cmd[:min(len(cmd), 120)])
+	}
+
+	// Env vars must be emitted in sorted key order (deterministic commands).
+	wantEnv := " -e RCLONE_CONFIG_MYS3_ACL=public-read -e RCLONE_CONFIG_MYS3_BUCKET_NAME=test-bucket -e RCLONE_CONFIG_MYS3_TYPE=s3"
+	if !strings.Contains(cmd, wantEnv) {
+		t.Errorf("command should contain sorted env flags %q. Got: %q", wantEnv, cmd)
+	}
+
+	if !strings.Contains(cmd, ` rclone/rclone:1.74.2 -ac "`) {
+		t.Errorf("command should invoke the rclone image with the -ac payload. Got: %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "set -o pipefail") {
+		t.Errorf("snapshot payload must set pipefail so a dying tar can't commit a truncated snapshot. Got: %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "mys3:/test-bucket/hoodi/erigon/123456/snapshot.tar.zst") {
+		t.Errorf("command should upload snapshot.tar.zst to the block dir. Got: %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "--exclude=./"+config.PreimagesOutDirName) {
+		t.Errorf("rendered tar payload should exclude the preimages scratch dir. Got: %q", cmd)
+	}
+}
+
+func TestBuildRCloneDockerCmdPreimagesUpload(t *testing.T) {
+	client := testSSHClient()
+
+	cmd, err := client.buildRCloneDockerCmd("/data/erigon", config.DefaultPreimagesUploadCmdTemplate, rcloneCmdVars{
+		DataDir:          "/data/erigon",
+		OutDir:           "/data/erigon/_snapshot_preimages",
+		UploadPathPrefix: "hoodi/erigon",
+		BucketName:       "test-bucket",
+		BlockNumber:      123456,
+	})
+	if err != nil {
+		t.Fatalf("buildRCloneDockerCmd failed: %v", err)
+	}
+
+	if !strings.Contains(cmd, "set -o pipefail") {
+		t.Errorf("preimages upload payload must set pipefail so a dying producer can't commit a truncated artifact. Got: %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "cd /data/erigon/_snapshot_preimages") {
+		t.Errorf("preimages upload payload should cd into the scratch dir. Got: %q", cmd)
+	}
+
+	// meta must be the FIRST tar member so consumers can stream it.
+	if !strings.Contains(cmd, "tar -I 'zstd -T64' -cf - preimages.meta.json framed.bin") {
+		t.Errorf("preimages upload payload must tar meta first, then framed.bin. Got: %q", cmd)
+	}
+
+	if !strings.Contains(cmd, "mys3:/test-bucket/hoodi/erigon/123456/preimages.tar.zst") {
+		t.Errorf("preimages upload payload should rcat to the block dir. Got: %q", cmd)
+	}
+
+	// A dying producer still leaves a committed partial object; the chain
+	// must remove it so a published block dir never holds a corrupt artifact.
+	if !strings.Contains(cmd, "|| ( rclone deletefile mys3:/test-bucket/hoodi/erigon/123456/preimages.tar.zst; exit 1 )") {
+		t.Errorf("preimages upload payload must delete the partial artifact on pipe failure. Got: %q", cmd)
+	}
+
+	// The preimages upload must never advance the per-client `latest` pointer.
+	if strings.Contains(cmd, "/latest") {
+		t.Errorf("preimages upload payload must never touch the latest pointer. Got: %q", cmd)
+	}
+}
+
+func TestRenderPreimagesExportCmd(t *testing.T) {
+	client := testSSHClient()
+
+	cmd, err := client.renderPreimagesExportCmd("ethpandaops/erigon:test", "/data/erigon")
+	if err != nil {
+		t.Fatalf("renderPreimagesExportCmd failed: %v", err)
+	}
+
+	want := `u="$(stat -c '%u:%g' /data/erigon)" && docker run --rm --user "$u" -v /data/erigon:/data/erigon ethpandaops/erigon:test snapshots export-preimages --datadir /data/erigon --out /data/erigon/_snapshot_preimages`
+	if cmd != want {
+		t.Errorf("rendered export command mismatch.\nGot:  %q\nWant: %q", cmd, want)
+	}
+}
+
+func TestResolvePreimagesImagePinned(t *testing.T) {
+	client := testSSHClient()
+	client.TargetConfig.Preimages.Image = "erigontech/erigon:main-latest"
+
+	// A pinned image must resolve without any remote call (no SSH available in tests).
+	image, err := client.ResolvePreimagesImage()
+	if err != nil {
+		t.Fatalf("ResolvePreimagesImage failed: %v", err)
+	}
+	if image != "erigontech/erigon:main-latest" {
+		t.Errorf("expected pinned image, got %q", image)
+	}
+}
+
+func TestResolvePreimagesImageRequiresPinOrContainer(t *testing.T) {
+	client := testSSHClient() // no pinned image, no execution container configured
+
+	_, err := client.ResolvePreimagesImage()
+	if err == nil || !strings.Contains(err.Error(), "no image pinned") {
+		t.Errorf("expected a config error when neither a pinned image nor an execution container is set, got: %v", err)
+	}
+}
+
+func TestCleanupPreimagesRefusesBadDataDir(t *testing.T) {
+	client := testSSHClient()
+
+	for _, bad := range []string{"", "/"} {
+		err := client.CleanupPreimages(bad)
+		if err == nil || !strings.Contains(err.Error(), "refusing to") {
+			t.Errorf("CleanupPreimages(%q) should refuse to run, got: %v", bad, err)
+		}
+	}
+}
+
+func TestExportAndUploadPreimagesRefusesBadDataDir(t *testing.T) {
+	client := testSSHClient()
+	client.TargetConfig.Preimages.Image = "erigontech/erigon:main-latest"
+
+	for _, bad := range []string{"", "/"} {
+		err := client.ExportAndUploadPreimages(bad, "hoodi/erigon", 123456)
+		if err == nil || !strings.Contains(err.Error(), "refusing to run") {
+			t.Errorf("ExportAndUploadPreimages(%q) should refuse before any remote call, got: %v", bad, err)
+		}
+	}
+}
+
+func TestValidateStateRootsOutput(t *testing.T) {
+	root := "0x1a2b3c4d5e6f70819a2b3c4d5e6f70819a2b3c4d5e6f70819a2b3c4d5e6f7081"
+	otherRoot := "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+	cases := []struct {
+		name    string
+		out     string
+		wantErr bool
+	}{
+		{"matching roots", root + "\n" + root + "\n", false},
+		{"malformed roots missing 0x prefix", strings.ToUpper(root[2:]) + "\n" + strings.ToUpper(root[2:]) + "\n", true},
+		{"case-insensitive match", root + "\n0x" + strings.ToUpper(root[2:]) + "\n", false},
+		{"mismatch", root + "\n" + otherRoot + "\n", true},
+		{"null value", root + "\nnull\n", true},
+		{"empty output", "", true},
+		{"single line", root + "\n", true},
+		{"noise then valid pair", "sudo: unable to resolve host xyz\n" + root + "\n" + root + "\n", false},
+		{"interleaved sudo noise", "sudo: unable to resolve host xyz\n" + root + "\nsudo: unable to resolve host xyz\n" + root + "\n", false},
+		{"trailing noise", root + "\n" + root + "\npam_unix(sudo:session): session closed\n", false},
+		{"three hex lines", root + "\n" + root + "\n" + root + "\n", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStateRootsOutput(tc.out)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for output %q", tc.out)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for output %q: %v", tc.out, err)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ type RCloneConfig struct {
 // .UploadPathPrefix is the prefix of the upload path ( e.g mainnet/geth)
 // .BlockNumber is the block number of the snapshot (e.g 123456)
 const DefaultRCloneCommandTemplate = `-ac "
+set -o pipefail &&
 apk add --no-cache tar zstd jq &&
 cd {{ .DataDir }} &&
 cat {{ .DataDir }}/_snapshot_metadata.json | jq . &&

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,13 +20,14 @@ type Config struct {
 			UseAgent                 bool   `yaml:"use_agent"`
 		} `yaml:"ssh"`
 		Snapshots struct {
-			CheckIntervalSeconds int           `yaml:"check_interval_seconds"`
-			BlockInterval        int           `yaml:"block_interval"`
-			DryRun               bool          `yaml:"dry_run"`
-			RunOnce              bool          `yaml:"run_once"`
-			Cleanup              CleanupConfig `yaml:"cleanup"`
-			RClone               RCloneConfig  `yaml:"rclone"`
-			S3                   S3Config      `yaml:"s3"`
+			CheckIntervalSeconds int             `yaml:"check_interval_seconds"`
+			BlockInterval        int             `yaml:"block_interval"`
+			DryRun               bool            `yaml:"dry_run"`
+			RunOnce              bool            `yaml:"run_once"`
+			Cleanup              CleanupConfig   `yaml:"cleanup"`
+			RClone               RCloneConfig    `yaml:"rclone"`
+			Preimages            PreimagesConfig `yaml:"preimages"`
+			S3                   S3Config        `yaml:"s3"`
 		} `yaml:"snapshots"`
 		Database struct {
 			Path string `yaml:"path"`
@@ -73,6 +74,7 @@ type SSHTargetConfig struct {
 		Beacon    string `yaml:"beacon"`
 		Execution string `yaml:"execution"`
 	} `yaml:"endpoints"`
+	Preimages PreimagesTargetConfig `yaml:"preimages"`
 }
 
 type RCloneConfig struct {
@@ -96,12 +98,54 @@ tar -I 'zstd -T64' \\
 --exclude=./nodekey \\
 --exclude=./key \\
 --exclude=./discovery-secret \\
+--exclude=./_snapshot_preimages \\
 -cvf - . \\
 | rclone rcat --s3-chunk-size 300M mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/{{ .BlockNumber }}/snapshot.tar.zst &&
 rclone copy {{ .DataDir }}/_snapshot_eth_getBlockByNumber.json mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/{{ .BlockNumber }} &&
 rclone copy {{ .DataDir }}/_snapshot_web3_clientVersion.json mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/{{ .BlockNumber }} &&
 rclone copy {{ .DataDir }}/_snapshot_metadata.json mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/{{ .BlockNumber }} &&
 echo {{ .BlockNumber }} | rclone rcat mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/latest
+"`
+
+// PreimagesConfig holds the global command templates for the erigon
+// state-preimages export/upload step (see erigontech/erigon#22645).
+type PreimagesConfig struct {
+	ExportCmdTemplate string `yaml:"export_cmd_template"`
+	UploadCmdTemplate string `yaml:"upload_cmd_template"`
+}
+
+// PreimagesTargetConfig enables preimage export for a single SSH target.
+type PreimagesTargetConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Image    string `yaml:"image"`    // empty = auto-detect from the execution container
+	Required bool   `yaml:"required"` // true = preimage failure fails the target/run
+}
+
+// PreimagesOutDirName is the scratch directory created inside the target's
+// datadir while exporting preimages. Must match the --exclude in
+// DefaultRCloneCommandTemplate.
+const PreimagesOutDirName = "_snapshot_preimages"
+
+// DefaultPreimagesExportCmdTemplate runs erigon's `snapshots export-preimages`
+// as a plain host command (single shell layer, $(...) expands on the host).
+// The container user is bound to the datadir owner; a failed stat aborts
+// instead of silently running as the image default user.
+// Vars: .Image .DataDir .OutDir
+const DefaultPreimagesExportCmdTemplate = `u="$(stat -c '%u:%g' {{ .DataDir }})" && docker run --rm --user "$u" -v {{ .DataDir }}:{{ .DataDir }} {{ .Image }} snapshots export-preimages --datadir {{ .DataDir }} --out {{ .OutDir }}`
+
+// DefaultPreimagesUploadCmdTemplate publishes preimages.tar.zst via the rclone
+// container. meta is the FIRST tar member (streamable without framed.bin), a
+// failed pipe deletes the partial object, and the per-client `latest` stays
+// owned by the snapshot template above.
+// Editing rule inside -ac "...": write $ as \$ and " as \"; no backticks.
+// Vars: .OutDir .BucketName .UploadPathPrefix .BlockNumber
+const DefaultPreimagesUploadCmdTemplate = `-ac "
+set -o pipefail &&
+apk add --no-cache tar zstd &&
+cd {{ .OutDir }} &&
+tar -I 'zstd -T64' -cf - preimages.meta.json framed.bin \\
+| rclone rcat --s3-chunk-size 300M mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/{{ .BlockNumber }}/preimages.tar.zst \\
+|| ( rclone deletefile mys3:/{{ .BucketName }}/{{ .UploadPathPrefix }}/{{ .BlockNumber }}/preimages.tar.zst; exit 1 )
 "`
 
 // GetDefaultRCloneConfig returns an RCloneConfig with sensible defaults
@@ -142,6 +186,14 @@ func ReadFromFile(path string) (*Config, error) {
 
 	if config.Global.Snapshots.RClone.Entrypoint == "" {
 		config.Global.Snapshots.RClone.Entrypoint = "/bin/sh"
+	}
+
+	if config.Global.Snapshots.Preimages.ExportCmdTemplate == "" {
+		config.Global.Snapshots.Preimages.ExportCmdTemplate = DefaultPreimagesExportCmdTemplate
+	}
+
+	if config.Global.Snapshots.Preimages.UploadCmdTemplate == "" {
+		config.Global.Snapshots.Preimages.UploadCmdTemplate = DefaultPreimagesUploadCmdTemplate
 	}
 
 	// Initialize RClone environment variables from the S3 configuration when available
@@ -201,6 +253,7 @@ func ReadFromFile(path string) (*Config, error) {
 	// Expand environment variables in SSH target paths
 	for i := range config.Targets.SSH {
 		config.Targets.SSH[i].DataDir = os.ExpandEnv(config.Targets.SSH[i].DataDir)
+		config.Targets.SSH[i].Preimages.Image = os.ExpandEnv(config.Targets.SSH[i].Preimages.Image)
 	}
 
 	return config, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -121,5 +122,85 @@ targets:
 	if cfg.Global.Snapshots.RClone.Env["RCLONE_CONFIG_MYS3_BUCKET_NAME"] != "test-bucket" {
 		t.Errorf("S3 bucket not propagated to RClone env correctly. Got %s, expected test-bucket",
 			cfg.Global.Snapshots.RClone.Env["RCLONE_CONFIG_MYS3_BUCKET_NAME"])
+	}
+}
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create temp config file: %v", err)
+	}
+	return path
+}
+
+func TestPreimagesDefaults(t *testing.T) {
+	cfg, err := ReadFromFile(writeTempConfig(t, `
+global:
+  chainID: "0x88bb0"
+  snapshots:
+    block_interval: 10
+targets:
+  ssh:
+    - alias: "erigon"
+      host: "127.0.0.1"
+      user: "test"
+      port: 22
+      data_dir: /data/erigon
+      upload_prefix: test/erigon
+`))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+
+	if cfg.Global.Snapshots.Preimages.ExportCmdTemplate != DefaultPreimagesExportCmdTemplate {
+		t.Errorf("Preimages export cmd template default not applied. Got %q", cfg.Global.Snapshots.Preimages.ExportCmdTemplate)
+	}
+	if cfg.Global.Snapshots.Preimages.UploadCmdTemplate != DefaultPreimagesUploadCmdTemplate {
+		t.Errorf("Preimages upload cmd template default not applied. Got %q", cfg.Global.Snapshots.Preimages.UploadCmdTemplate)
+	}
+
+	target := cfg.Targets.SSH[0].Preimages
+	if target.Enabled || target.Image != "" || target.Required {
+		t.Errorf("Target preimages config should be zero-valued when unset. Got %+v", target)
+	}
+}
+
+func TestPreimagesTargetParsingAndEnvExpansion(t *testing.T) {
+	if err := os.Setenv("TEST_ERIGON_IMAGE", "ethpandaops/erigon:test-tag"); err != nil {
+		t.Fatalf("Failed to set TEST_ERIGON_IMAGE: %v", err)
+	}
+
+	cfg, err := ReadFromFile(writeTempConfig(t, `
+global:
+  chainID: "0x88bb0"
+  snapshots:
+    block_interval: 10
+targets:
+  ssh:
+    - alias: "erigon"
+      host: "127.0.0.1"
+      user: "test"
+      port: 22
+      data_dir: /data/erigon
+      upload_prefix: test/erigon
+      preimages:
+        enabled: true
+        image: "$TEST_ERIGON_IMAGE"
+        required: true
+`))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+
+	target := cfg.Targets.SSH[0].Preimages
+	if !target.Enabled {
+		t.Error("Target preimages should be enabled")
+	}
+	if target.Image != "ethpandaops/erigon:test-tag" {
+		t.Errorf("Target preimages image not expanded correctly. Got %q, expected ethpandaops/erigon:test-tag", target.Image)
+	}
+	if !target.Required {
+		t.Error("Target preimages should be required")
 	}
 }

--- a/internal/snapshotter/snapshotter.go
+++ b/internal/snapshotter/snapshotter.go
@@ -96,6 +96,7 @@ func Init(cfg *config.Config) (*SnapShotter, error) {
 				cfg.Global.SSH.InsecureIgnoreHostKey,
 				cfg.Global.SSH.UseAgent,
 				&cfg.Global.Snapshots.RClone,
+				&cfg.Global.Snapshots.Preimages,
 				&cfg.Targets.SSH[i],
 			),
 			cfg: &tt,
@@ -433,6 +434,40 @@ func (s *SnapShotter) PrepareForSnapshot() error {
 		return nil
 	}
 
+	// Preflight: pull pinned preimage images while everything still runs, so
+	// a required-target failure aborts with zero downtime.
+	pullGroup := errgroup.Group{}
+	for _, t := range s.sshTargets {
+		if !t.cfg.Preimages.Enabled {
+			continue
+		}
+		cl := t.client
+		tt := t
+		if tt.cfg.Preimages.Image == "" {
+			// Auto-detect needs no pull, but requires an execution container.
+			if tt.cfg.DockerContainers.Execution == "" {
+				err := fmt.Errorf("preimages enabled for %s but no image pinned and no execution container configured", tt.cfg.Alias)
+				if tt.cfg.Preimages.Required {
+					return err
+				}
+				log.WithError(err).Warn("preimages misconfigured (best-effort)")
+			}
+			continue
+		}
+		pullGroup.Go(func() error {
+			if err := cl.PullDockerImage(tt.cfg.Preimages.Image); err != nil {
+				if tt.cfg.Preimages.Required {
+					return fmt.Errorf("preflight pull of preimages image failed for %s: %w", tt.cfg.Alias, err)
+				}
+				log.WithError(err).Warnf("preflight pull of preimages image failed for %s (best-effort)", tt.cfg.Alias)
+			}
+			return nil
+		})
+	}
+	if err := pullGroup.Wait(); err != nil {
+		return err
+	}
+
 	// Stop snooper
 	log.Info("stopping snooper container across targets")
 	group := errgroup.Group{}
@@ -641,6 +676,22 @@ func (s *SnapShotter) UploadSnapshot(runID int64) error {
 		}
 
 		group.Go(func() error {
+			// Export and upload state preimages first: the per-client `latest`
+			// pointer is the final step of the snapshot upload chain, so it
+			// only ever advances after the preimages artifact is in place.
+			if tt.cfg.Preimages.Enabled {
+				if err := cl.ExportAndUploadPreimages(tt.cfg.DataDir, tt.cfg.UploadPrefix, s.status.ProcessedBlockHeight); err != nil {
+					if tt.cfg.Preimages.Required {
+						if errDB := s.db.UpdateTargetSnapshotStatus(targetSnapshot.ID, "failed", "preimages: "+err.Error()); errDB != nil {
+							log.WithError(errDB).Error("failed to update target snapshot status")
+						}
+						log.WithError(err).Errorf("preimages export/upload failed for required target %s", cl.TargetConfig.Alias)
+						return err
+					}
+					log.WithError(err).Warnf("preimages export/upload failed for %s (best-effort, continuing with snapshot)", cl.TargetConfig.Alias)
+				}
+			}
+
 			err := cl.RCloneSyncLocalToRemote(tt.cfg.DataDir, tt.cfg.UploadPrefix, s.status.ProcessedBlockHeight)
 			if err != nil {
 				if errDB := s.db.UpdateTargetSnapshotStatus(targetSnapshot.ID, "failed", err.Error()); errDB != nil {


### PR DESCRIPTION
Reopening https://github.com/ethpandaops/snapshotter/pull/39 from @CPerezz here so that we can build a docker image on CI to test it ( The image build doesn't work from a forked repo) . 